### PR TITLE
using express-prep-client under the hood to boot express apps in the client side

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -5,191 +5,19 @@
  */
 
 /*jshint eqeqeq: false*/
-
+/*global app*/
 /**
-Provides a set of features
-to control a YUI instance on the client side. This module will be
-serialized and sent to the client side thru `res.expose()` and available
-in the client side thru `window.app.yui`.
+Provides a set of features to control a YUI instance on the client side.
+This module will be serialized and sent to the client side using `express-prep-client`.
 
 @module express-yui/lib/client
 **/
 
 var utils = require('./utils');
 
-/**
-Provides a set of methods to be serialized and sent to the client side to boot
-the application in the browser.
-
-@class client
-@static
-@uses utils
-@extensionfor express-yui/lib/yui
-*/
-function bootstrap(method, args) {
-
-    var self = this,
-        d = document,
-        head = d.getElementsByTagName('head')[0],
-        // Some basic browser sniffing...
-        ie = /MSIE/.test(navigator.userAgent),
-        // it is just a queue of pending "use" statements until YUI gets ready
-        callback = [],
-        config = typeof YUI_config != "undefined" ? YUI_config : {};
-
-    function flush() {
-        var l = callback.length,
-            i;
-        if (!self.YUI && typeof YUI == "undefined") {
-            throw new Error("YUI was not injected correctly!");
-        }
-        self.YUI = self.YUI || YUI;
-        // callback on every pending use statement
-        for (i = 0; i < l; i++) {
-            callback.shift()();
-        }
-    }
-
-    function decrementRequestPending() {
-        self._pending--;
-        if (self._pending <= 0) {
-            setTimeout(flush, 0);
-        } else {
-            // in case there is any remaining script to be loaded
-            load();
-        }
-    }
-
-    function createScriptNode(src) {
-        var node = d.createElement('script');
-        // use async=false for ordered async?
-        // parallel-load-serial-execute http://wiki.whatwg.org/wiki/Dynamic_Script_Execution_Order
-        if (node.async) {
-            node.async = false;
-        }
-        if (ie) {
-            node.onreadystatechange = function () {
-                if (/loaded|complete/.test(this.readyState)) {
-                    this.onreadystatechange = null;
-                    decrementRequestPending();
-                }
-            };
-        } else {
-            node.onload = node.onerror = decrementRequestPending;
-        }
-        node.setAttribute('src', src);
-        return node;
-    }
-
-    function load() {
-        if (!config.seed) {
-            throw new Error('YUI_config.seed array is required.');
-        }
-        var seed = config.seed,
-            l = seed.length,
-            i, node;
-
-        if (!self._injected) {
-            // flagging the injection process to avoid duplicated entries
-            self._injected = true;
-            self._pending = seed.length;
-        }
-
-        // appending every file from seed collection into the header
-        for (i = 0; i < l; i++) {
-            node = createScriptNode(seed.shift());
-            head.appendChild(node);
-            // TODO: if original node.async is undefined, it means the order has
-            // to be preserved manually, in which case we should insert
-            // them one by one to guarantee serial execute
-            if (node.async !== false) {
-                break;
-            }
-        }
-
-    }
-
-    callback.push(function () {
-        var i;
-
-        if (!self._Y) {
-            // extend core (YUI_config.extendedCore)
-            self.YUI.Env.core.push.apply(self.YUI.Env.core, config.extendedCore || []);
-            // create unique instance which is accesible thru app.yui.use()
-            self._Y = self.YUI();
-            self.use = self._Y.use;
-
-            if (config.patches && config.patches.length) {
-                for (i = 0; i < config.patches.length; i += 1) {
-                    config.patches[i](self._Y, self._Y.Env._loader);
-                }
-            }
-        }
-        // call use/require with arguments
-        self._Y[method].apply(self._Y, args);
-    });
-
-    // just in case YUI was injected manually in the page
-    self.YUI = self.YUI || (typeof YUI != "undefined" ? YUI : null);
-
-    if (!self.YUI && !self._injected) {
-        // attach seed and wait for it to finish to flush the callback
-        load();
-    } else if (self._pending <= 0) {
-        // everything is ready, just flush on the next tick
-        setTimeout(flush, 0);
-    } // else do nothing, the current pending job will take care of flushing callback
-
-    return this; // chaining
-}
-
+// NOTE: these two functions are meant to be executed in the client side
+//       and for that, they will be serialized and mocked by prep-client
 module.exports = {
-
-    /**
-    Attaches the seed into the head, then creates a YUI Instance and attaches
-    `modules` into it. This is equivalent to `YUI().use()` after getting the seed
-    ready. This method is a bootstrap implementation for the library, and the way
-    you use this in your templates, is by doing this:
-
-        <script>{{{state}}}</script>
-        <script>
-        app.yui.use('foo', 'bar', function (Y) {
-            // do something!
-        });
-        </script>
-
-    Where `state` defines the state of the express app, and `app.yui` defines
-    the helpers that `express-yui` brings into the client side.
-
-    @method use
-    @public
-    @chainable
-    **/
-    use: utils.minifyFunction(function () {
-        return this._bootstrap('use', [].slice.call(arguments));
-    }),
-
-    /**
-    Like `app.yui.use()` but instead delegates to `YUI().require()` after
-    getting the seed ready. The callback passed to `require()` receives two
-    arguments, the `Y` object like `use()`, but also `imports` which holds all
-    of the exports from the required modules.
-
-        <script>{{{state}}}</script>
-        <script>
-        app.yui.require('foo', 'bar', function (Y, imports) {
-            var Foo         = imports['foo'],
-                namedExport = imports['bar'].baz;
-        });
-        </script>
-
-    @method require
-    @public
-    **/
-    require: utils.minifyFunction(function () {
-        this._bootstrap('require', [].slice.call(arguments));
-    }),
-
     /**
     Boots the application, rehydrate the app state and calls back to notify the
     `ready` state of the app.
@@ -211,19 +39,70 @@ module.exports = {
                         will be passed as the first argument of the callback function.
     @public
     **/
-    ready: utils.minifyFunction(function (callback) {
-        this.use(function () {
-            callback();
+    "app.yui.ready": utils.minifyFunction(function (callback) {
+        var config, i, Y;
+        if (!app.yui._Y) {
+            config = typeof YUI_config !== undefined ? YUI_config : {};
+            // extend core (YUI_config.extendedCore)
+            YUI.Env.core.push.apply(YUI.Env.core, config.extendedCore || []);
+            // create unique instance which is accesible thru app.yui.use()
+            Y = app.yui._Y = YUI();
+            app.yui.use = Y.use;
+            app.yui.require = Y.require;
+            // applying loader patches
+            if (config.patches && config.patches.length) {
+                for (i = 0; i < config.patches.length; i += 1) {
+                    config.patches[i](Y, Y.Env._loader);
+                }
+            }
+        }
+        callback();
+    }),
+
+    /**
+    This method is a bootstrap implementation for the library, and the way
+    you use this in your templates, is by doing this:
+
+        <script>{{{state}}}</script>
+        <script>
+        app.yui.use('foo', 'bar', function (Y) {
+            // do something!
+        });
+        </script>
+
+    This method is mocked by `express-prep-client` to guarantee the timeline.
+
+    @method use
+    @public
+    **/
+    "app.yui.use": utils.minifyFunction(function () {
+        var a = arguments;
+        app.yui.ready(function () {
+            app.yui.use.apply(app.yui._Y, a);
         });
     }),
 
     /**
-    The internal bootstraping implementation.
+    Like `app.yui.use()` but instead delegates to `YUI().require()`. The callback
+    passed to `require()` receives two arguments, the `Y` object like `use()`,
+    but also `imports` which holds all of the exports from the required modules.
 
-    @method _bootstrap
-    @param {String} method The method to call on `Y`, either `"use"` or `"require"`.
-    @param {Any[]} args Array of `arguments` to apply to the `Y` `method`.
-    @private
-    */
-    _bootstrap: utils.minifyFunction(bootstrap)
+        <script>{{{state}}}</script>
+        <script>
+        app.yui.require('foo', 'bar', function (Y, imports) {
+            var Foo         = imports['foo'],
+                namedExport = imports['bar'].baz;
+        });
+        </script>
+
+    @method require
+    @public
+    **/
+    "app.yui.require": utils.minifyFunction(function () {
+        var a = arguments;
+        app.yui.ready(function () {
+            app.yui.require.apply(app.yui._Y, a);
+        });
+    })
+
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,8 +15,7 @@ yui capabilities to express applications.
 
 'use strict';
 
-var expstate = require('express-state'),
-    YUIClass = require('./yui'),
+var YUIClass = require('./yui'),
     middleware = require('./middleware'),
     utils = require('./utils');
 
@@ -26,7 +25,8 @@ function ExpressYUI(app) {
     // Brand.
     Object.defineProperty(app, '@yui', { value: ExpressYUI });
     // extend express with some other requirements.
-    expstate.extend(app);
+    require('express-state').extend(app);
+    require('express-prep-client').extend(app, require('./client.js'));
     // adding the `yui` member.
     app.yui = new YUIClass(app);
     return app;
@@ -75,7 +75,7 @@ module.exports = utils.extend({
 
     /**
     Extends an express application instance with `express-yui` functionalities.
-    
+
     @method extend
     @static
     @public

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -16,8 +16,7 @@ expose static assests that are YUI related.
 
 'use strict';
 
-var client = require('./client'),
-    utils = require('./utils');
+var utils = require('./utils');
 
 /**
 Exports few middleware.
@@ -30,13 +29,7 @@ Exports few middleware.
 module.exports = {
 
     /**
-    Exposes the yui configuration into `app.locals.state`. It also
-    exposes the `express-yui` wrapper for YUI on the client so you can
-    access `app.yui.*` on the client side just like you do on the server
-    side. The client wrapper includes `app.yui.ready()` and `app.yui.use()`
-    with the corresponding bootstraping code to inject YUI into the page.
-    This middleware will be invoked by `expyui.expose()` middleware
-    automatically, which means you do not need to call it directly.
+    Exposes the yui configuration into `app.locals.state`.
 
     @method exposeConfig
     @protected
@@ -54,10 +47,8 @@ module.exports = {
             if (!yui_config && req.app && req.app.yui) {
                 // one time operation to compute the initial configuration
                 yui_config = configCache = req.app.yui.config();
-
                 // exposing the `YUI_config`
                 req.app.expose(yui_config, 'window.YUI_config', {cache: true});
-                req.app.expose(client, 'window.app.yui', {cache: true});
             }
 
             next();
@@ -93,8 +84,16 @@ module.exports = {
                 // one time operation to compute the initial configuration and seed.
                 yui_config = configCache = req.app.yui.config();
                 yui_seed = seedCache = req.app.yui.getSeedUrls();
-
+                // exposing the seed urls
                 req.app.expose(yui_seed, 'window.YUI_config.seed', {cache: true});
+                // if YUI is not defined yet in the page, the seed urls should
+                // be used to prepare the client runtime
+                req.app.prepClient({
+                    testFn: function () {
+                        this.nope = YUI_config.seed; // trick to control the `nope` dynamically for BC
+                        return !!window.YUI;
+                    }
+                });
             }
 
             next();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,7 @@
  * See the accompanying LICENSE file for terms.
  */
 
-/*jslint node:true, nomen: true */
+/*jslint -W061, -W058, -W064*/
 
 /**
 Utility functions used across `express-yui` components.
@@ -102,8 +102,7 @@ it to the client side as a js blob.
 @return {Function} the minified function
 **/
 exports.minifyFunction = function (fn) {
-    var fnString = fn.toString(),
-        forcingFunctionEval = Function; // f**k you jshint!
+    var fnString = fn.toString();
     // removing comments (http://upshots.org/javascript/javascript-regexp-to-remove-comments)
     fnString = fnString.replace(/(\/\*([\s\S]*?)\*\/)|(\/\/(.*)$)/gm, '');
     // removing breaklines, tabs and spaces
@@ -114,7 +113,7 @@ exports.minifyFunction = function (fn) {
         .replace(/\t/g, '')
         .replace(/\ +/g, ' ');
 
-    return forcingFunctionEval('return ' + fnString)();
+    return Function('return ' + fnString)();
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
         "yui-lint": "~0.1.3",
         "yuitest": "0.7.x",
         "yuidocjs": ">=0.3.46",
-        "ypromise": "^0.2.3"
+        "ypromise": "^0.2.3",
+        "express-prep-client": "*"
     },
     "main": "./lib/",
     "keywords": [

--- a/tests/units/middleware-test.js
+++ b/tests/units/middleware-test.js
@@ -101,6 +101,10 @@ suite.add(new YUITest.TestCase({
                             'seed[1] does not match');
             }
         });
+        YUITest.Mock.expect(req.app, {
+            method: 'prepClient',
+            args: [YUITest.Mock.Value.Any]
+        });
 
         mid = middleware.exposeSeed();
         mid(req, res, function () {


### PR DESCRIPTION
Changes:
- non-BC change on `app.yui.use()`, it is not longer chainable.

/cc @ericf
