### PR TITLE
Respect maxURLLength parameter in seed URL builder

### DIFF
--- a/lib/seed.js
+++ b/lib/seed.js
@@ -252,6 +252,7 @@ module.exports = {
             groups = config.groups || {},
             prevGroup,
             stack = [],
+            urlLength,
             groupName,
             groupConfig,
             path,
@@ -264,6 +265,21 @@ module.exports = {
                 urls.push(prevGroup.comboBase + stack.join(prevGroup.comboSep));
             }
             stack = [];
+            urlLength = null;
+        }
+
+        function peek(groupConfig, path) {
+            if (!urlLength) {
+                urlLength = groupConfig.comboBase.length;
+            }
+            if (stack.length > 0) {
+                urlLength += groupConfig.comboSep.length;
+            }
+
+            urlLength += groupConfig.root.length;
+            urlLength += path.length;
+
+            return urlLength;
         }
 
         function isSimilarGroup(newGroup) {
@@ -300,6 +316,10 @@ module.exports = {
                     flush(groupConfig);
                 }
                 if (customConfig.combine !== false && groupConfig.combine) {
+                    if (peek(groupConfig, path) >= groupConfig.maxURLLength) {
+                        flush(groupConfig);
+                    }
+
                     stack.push(groupConfig.root + path);
                 } else {
                     urls.push(groupConfig.base + path);

--- a/lib/seed.js
+++ b/lib/seed.js
@@ -252,7 +252,7 @@ module.exports = {
             groups = config.groups || {},
             prevGroup,
             stack = [],
-            urlLength,
+            stackURLLength = 0,
             groupName,
             groupConfig,
             path,
@@ -265,21 +265,21 @@ module.exports = {
                 urls.push(prevGroup.comboBase + stack.join(prevGroup.comboSep));
             }
             stack = [];
-            urlLength = null;
+            stackURLLength = 0;
         }
 
         function peek(groupConfig, path) {
-            if (!urlLength) {
-                urlLength = groupConfig.comboBase.length;
+            if (stackURLLength === 0) {
+                stackURLLength = groupConfig.comboBase.length;
             }
             if (stack.length > 0) {
-                urlLength += groupConfig.comboSep.length;
+                stackURLLength += groupConfig.comboSep.length;
             }
 
-            urlLength += groupConfig.root.length;
-            urlLength += path.length;
+            stackURLLength += groupConfig.root.length;
+            stackURLLength += path.length;
 
-            return urlLength;
+            return stackURLLength;
         }
 
         function isSimilarGroup(newGroup) {

--- a/tests/units/seed-test.js
+++ b/tests/units/seed-test.js
@@ -234,8 +234,57 @@ suite.add(new YUITest.TestCase({
         A.areEqual('/app-base/cssfoo/cssfoo-min.css',
                     urls[1],
                     'urls[1] does not match');
-    }
+    },
 
+    "test buildCSSUrls() with combine": function () {
+      var yui_config;
+
+      yui_config = {
+          base: '/app/',
+          root: '/app/',
+          combine: true,
+          comboBase: 'http://foo.bar/combo?',
+          comboSep: '~'
+      };
+      seed.config = function () {
+          return yui_config;
+      };
+      seed._clientModules = { };
+
+      var urls = seed.buildCSSUrls('cssbase', 'cssfoo');
+
+      A.areEqual(1, urls.length, '1 css expected');
+      A.areEqual('http://foo.bar/combo?/app/cssbase/cssbase-min.css~/app/cssfoo/cssfoo-min.css',
+                  urls[0],
+                  'urls[0] does not match');
+    },
+
+    "test buildCSSUrls() with combine and maxURLLength": function () {
+      var yui_config;
+
+      yui_config = {
+          base: '/app/',
+          root: '/app/',
+          combine: true,
+          comboBase: 'http://foo.bar/combo?',
+          comboSep: '~',
+          maxURLLength: 60 // intentionally break
+      };
+      seed.config = function () {
+          return yui_config;
+      };
+      seed._clientModules = { };
+
+      var urls = seed.buildCSSUrls('cssbase', 'cssfoo');
+
+      A.areEqual(2, urls.length, '2 css expected');
+      A.areEqual('http://foo.bar/combo?/app/cssbase/cssbase-min.css',
+                  urls[0],
+                  'urls[0] does not match');
+      A.areEqual('http://foo.bar/combo?/app/cssfoo/cssfoo-min.css',
+                  urls[1],
+                  'urls[1] does not match');
+    }
 }));
 
 YUITest.TestRunner.add(suite);


### PR DESCRIPTION
This makes the `_buildUrls` method in seed.js respect the `maxURLLength` option for combo urls.

/cc @caridy @drewfish @ericf @bertrandom 
